### PR TITLE
Improve the readme generated by the starter code

### DIFF
--- a/runtime/src/main/codestarts/quarkus/qute-web-codestart/codestart.yml
+++ b/runtime/src/main/codestarts/quarkus/qute-web-codestart/codestart.yml
@@ -4,6 +4,6 @@ tags: extension-codestart
 type: code
 metadata:
   title: Qute Web
-  description: Create your web page using Quarkus and Qute
+  description: Qute templates like `some-page.html` served via HTTP automatically by Quarkus from the `src/main/resource/templates/pub` directory. No controllers needed. Once the quarkus app is started visit the generated page at http://localhost:8080/some-page?name=World
   path: /some-page
-  related-guide-section: https://quarkus.io/guides/qute#type-safe-templates
+  related-guide-section: https://docs.quarkiverse.io/quarkus-qute-web/dev/index.html


### PR DESCRIPTION
Similar to https://github.com/quarkiverse/quarkus-web-bundler/pull/264.

I have been generating different setup with https://code.quarkus.io/, for me it is important to summarize in the generated readme what the code-start is about and what can be tested