### PR TITLE
Update version in markdown.adoc

### DIFF
--- a/docs/modules/ROOT/pages/markdown.adoc
+++ b/docs/modules/ROOT/pages/markdown.adoc
@@ -14,7 +14,7 @@ To install the extension, add the following dependency to your project:
 <dependency>
     <groupId>io.quarkiverse.qute-markdown</groupId>
     <artifactId>quarkus-qute-web-markdown</artifactId>
-    <version>999-SNAPSHOT</version>
+    <version>{project-version}</version>
 </dependency>
 ----
 


### PR DESCRIPTION
The version:

```xml
<dependency>
    <groupId>io.quarkiverse.qute-markdown</groupId>
    <artifactId>quarkus-qute-web-markdown</artifactId>
    <version>3.1.0</version>
</dependency>
```

Was released on maven central: https://repo.maven.apache.org/maven2/io/quarkiverse/qute/web/quarkus-qute-web-markdown/3.1.0/