### PR TITLE
Fix RawString issue with Asciidoc and Markdown template extensions

### DIFF
--- a/asciidoc/runtime/src/main/java/io/quarkiverse/qute/web/asciidoc/runtime/AsciidocSectionHelperFactory.java
+++ b/asciidoc/runtime/src/main/java/io/quarkiverse/qute/web/asciidoc/runtime/AsciidocSectionHelperFactory.java
@@ -5,6 +5,7 @@ import java.util.concurrent.CompletionStage;
 
 import io.quarkus.qute.CompletedStage;
 import io.quarkus.qute.EngineConfiguration;
+import io.quarkus.qute.RawString;
 import io.quarkus.qute.ResultNode;
 import io.quarkus.qute.SectionHelper;
 import io.quarkus.qute.SectionHelperFactory;
@@ -29,8 +30,8 @@ public class AsciidocSectionHelperFactory
     }
 
     @TemplateExtension(matchNames = { "asciidocify", "asciidocToHtml" })
-    static String convertToAsciidoc(String text, String ignoredName) {
-        return CONVERTER.apply(text);
+    static RawString convertToAsciidoc(String text, String ignoredName) {
+        return new RawString(CONVERTER.apply(text));
     }
 
     public static class AsciidocSectionHelper implements SectionHelper {

--- a/markdown/runtime/src/main/java/io/quarkiverse/qute/web/markdown/runtime/MarkdownSectionHelperFactory.java
+++ b/markdown/runtime/src/main/java/io/quarkiverse/qute/web/markdown/runtime/MarkdownSectionHelperFactory.java
@@ -9,6 +9,7 @@ import io.quarkus.arc.Arc;
 import io.quarkus.arc.impl.LazyValue;
 import io.quarkus.qute.CompletedStage;
 import io.quarkus.qute.EngineConfiguration;
+import io.quarkus.qute.RawString;
 import io.quarkus.qute.ResultNode;
 import io.quarkus.qute.SectionHelper;
 import io.quarkus.qute.SectionHelperFactory;
@@ -47,8 +48,8 @@ public class MarkdownSectionHelperFactory
             () -> Arc.container().instance(MdConverter.class).get());
 
     @TemplateExtension(matchNames = { "markdownify", "mdToHtml" })
-    static String convertToMarkdown(String text, String ignoredName) {
-        return CONVERTER.get().html(text);
+    static RawString convertToMarkdown(String text, String ignoredName) {
+        return new RawString(CONVERTER.get().html(text));
     }
 
     public static class MarkdownSectionHelper implements SectionHelper {


### PR DESCRIPTION
This allows to do https://github.com/quarkiverse/quarkus-qute-web/issues/146 but without the need of using `.raw`.

Closes #146