### PR TITLE
Fix `quarkus-qute-web-markdown` groupId in docs

### DIFF
--- a/docs/modules/ROOT/pages/markdown.adoc
+++ b/docs/modules/ROOT/pages/markdown.adoc
@@ -12,7 +12,7 @@ To install the extension, add the following dependency to your project:
 [source,xml,subs=attributes+]
 ----
 <dependency>
-    <groupId>io.quarkiverse.qute-markdown</groupId>
+    <groupId>io.quarkiverse.qute.web</groupId>
     <artifactId>quarkus-qute-web-markdown</artifactId>
     <version>{project-version}</version>
 </dependency>


### PR DESCRIPTION
https://docs.quarkiverse.io/quarkus-qute-web/dev/markdown.html#_installation shows the wrong `<groupId>`