### PR TITLE
3.4.0

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,3 +1,3 @@
 release:
-  current-version: "3.3.0"
+  current-version: "3.4.0"
   next-version: "999-SNAPSHOT"


### PR DESCRIPTION
This release drop Markdown plugins extensions (tables, autolink, anchor) in favour of configuration on the base markdown extension.