### PR TITLE
Use VertxHttpBuildTimeConfig instead of HttpBuildTimeConfig

### DIFF
--- a/core/runtime/src/main/java/io/quarkiverse/qute/web/runtime/QuteWebHandler.java
+++ b/core/runtime/src/main/java/io/quarkiverse/qute/web/runtime/QuteWebHandler.java
@@ -29,7 +29,7 @@ import io.quarkus.qute.runtime.TemplateProducer;
 import io.quarkus.security.identity.CurrentIdentityAssociation;
 import io.quarkus.security.identity.SecurityIdentity;
 import io.quarkus.vertx.http.runtime.CurrentVertxRequest;
-import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
+import io.quarkus.vertx.http.runtime.VertxHttpBuildTimeConfig;
 import io.quarkus.vertx.http.runtime.security.QuarkusHttpUser;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
@@ -60,7 +60,7 @@ public class QuteWebHandler implements Handler<RoutingContext> {
     private final List<DataInitializer> dataInitializers;
 
     public QuteWebHandler(String rootPath, String publicDir, Set<String> templatePaths, Map<String, String> templateLinks,
-            HttpBuildTimeConfig httpBuildTimeConfig) {
+            VertxHttpBuildTimeConfig httpBuildTimeConfig) {
         this.rootPath = rootPath;
         this.templatePaths = templatePaths;
         if (publicDir.equals("/") || publicDir.isBlank()) {
@@ -69,8 +69,8 @@ public class QuteWebHandler implements Handler<RoutingContext> {
             this.webTemplatesPath = publicDir.startsWith("/") ? publicDir.substring(1) : publicDir;
         }
         this.templateLinks = templateLinks;
-        this.compressMediaTypes = httpBuildTimeConfig.enableCompression
-                ? httpBuildTimeConfig.compressMediaTypes.orElse(List.of())
+        this.compressMediaTypes = httpBuildTimeConfig.enableCompression()
+                ? httpBuildTimeConfig.compressMediaTypes().orElse(List.of())
                 : null;
         this.extractedPaths = new ConcurrentHashMap<>();
         ArcContainer container = Arc.container();

--- a/core/runtime/src/main/java/io/quarkiverse/qute/web/runtime/QuteWebRecorder.java
+++ b/core/runtime/src/main/java/io/quarkiverse/qute/web/runtime/QuteWebRecorder.java
@@ -4,8 +4,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
 
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
-import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
+import io.quarkus.vertx.http.runtime.VertxHttpBuildTimeConfig;
 import io.vertx.core.Handler;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.ext.web.Route;
@@ -14,10 +15,11 @@ import io.vertx.ext.web.RoutingContext;
 @Recorder
 public class QuteWebRecorder {
 
-    private final HttpBuildTimeConfig httpConfig;
-    private final QuteWebBuildTimeConfig quteWebConfig;
+    private final RuntimeValue<VertxHttpBuildTimeConfig> httpConfig;
+    private final RuntimeValue<QuteWebBuildTimeConfig> quteWebConfig;
 
-    public QuteWebRecorder(HttpBuildTimeConfig httpConfig, QuteWebBuildTimeConfig quteWebConfig) {
+    public QuteWebRecorder(RuntimeValue<VertxHttpBuildTimeConfig> httpConfig,
+            RuntimeValue<QuteWebBuildTimeConfig> quteWebConfig) {
         this.httpConfig = httpConfig;
         this.quteWebConfig = quteWebConfig;
     }
@@ -28,13 +30,14 @@ public class QuteWebRecorder {
             @Override
             public void accept(Route r) {
                 r.method(HttpMethod.GET);
-                r.order(quteWebConfig.routeOrder());
+                r.order(quteWebConfig.getValue().routeOrder());
             }
         };
     }
 
     public Handler<RoutingContext> handler(String rootPath,
             Set<String> templatePaths, Map<String, String> templateLinks) {
-        return new QuteWebHandler(rootPath, quteWebConfig.publicDir(), templatePaths, templateLinks, httpConfig);
+        return new QuteWebHandler(rootPath, quteWebConfig.getValue().publicDir(), templatePaths, templateLinks,
+                httpConfig.getValue());
     }
 }

--- a/docs/modules/ROOT/pages/includes/quarkus-qute-web-asciidoc.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-qute-web-asciidoc.adoc
@@ -1,4 +1,3 @@
-:summaryTableId: quarkus-qute-web-asciidoc_quarkus-asciidoc
 [.configuration-legend]
 icon:lock[title=Fixed at build time] Configuration property fixed at build time - All other configuration properties are overridable at runtime
 [.configuration-reference.searchable, cols="80,.^10,.^10"]
@@ -9,6 +8,10 @@ h|Type
 h|Default
 
 a|icon:lock[title=Fixed at build time] [[quarkus-qute-web-asciidoc_quarkus-asciidoc-attributes-attributes]] [.property-path]##link:#quarkus-qute-web-asciidoc_quarkus-asciidoc-attributes-attributes[`quarkus.asciidoc.attributes."attributes"`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.asciidoc.attributes."attributes"+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -31,5 +34,3 @@ endif::add-copy-button-to-env-var[]
 
 |===
 
-
-:!summaryTableId:

--- a/docs/modules/ROOT/pages/includes/quarkus-qute-web-asciidoc_quarkus.asciidoc.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-qute-web-asciidoc_quarkus.asciidoc.adoc
@@ -1,4 +1,3 @@
-:summaryTableId: quarkus-qute-web-asciidoc_quarkus-asciidoc
 [.configuration-legend]
 icon:lock[title=Fixed at build time] Configuration property fixed at build time - All other configuration properties are overridable at runtime
 [.configuration-reference.searchable, cols="80,.^10,.^10"]
@@ -9,6 +8,10 @@ h|Type
 h|Default
 
 a|icon:lock[title=Fixed at build time] [[quarkus-qute-web-asciidoc_quarkus-asciidoc-attributes-attributes]] [.property-path]##link:#quarkus-qute-web-asciidoc_quarkus-asciidoc-attributes-attributes[`quarkus.asciidoc.attributes."attributes"`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.asciidoc.attributes."attributes"+++[]
+endif::add-copy-button-to-config-props[]
+
 
 [.description]
 --
@@ -31,5 +34,3 @@ endif::add-copy-button-to-env-var[]
 
 |===
 
-
-:!summaryTableId:


### PR DESCRIPTION
- in order to make the extension compatible with Quarkus 3.26; where the deprecated HttpBuildTimeConfig is removed