### PR TITLE
Enable to use mermaid blocks in asciidoc-java integration module

### DIFF
--- a/asciidoc/runtime/pom.xml
+++ b/asciidoc/runtime/pom.xml
@@ -25,6 +25,12 @@
             <artifactId>ascii2svg</artifactId>
             <version>${asciidoc.java.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/asciidoc/runtime/src/main/java/io/quarkiverse/qute/web/asciidoc/runtime/AsciidocConfig.java
+++ b/asciidoc/runtime/src/main/java/io/quarkiverse/qute/web/asciidoc/runtime/AsciidocConfig.java
@@ -17,6 +17,10 @@ public interface AsciidocConfig {
      * <ul>
      * <li><code>noheader=true</code></li>
      * </ul>
+     * <p>
+     * Note that <code>mermaid-skipModule</code> attribute presence will not inject mermaid.js script
+     * so you will have to ensure it is present in your layout/scripts by default.
+     * If not set it will be injected using a <pre>cdn.jsdelivr.net</pre> url and version 11.
      */
     Map<String, String> attributes();
 

--- a/asciidoc/runtime/src/main/java/io/quarkiverse/qute/web/asciidoc/runtime/AsciidocConverter.java
+++ b/asciidoc/runtime/src/main/java/io/quarkiverse/qute/web/asciidoc/runtime/AsciidocConverter.java
@@ -17,7 +17,6 @@ import io.yupiik.asciidoc.model.Document;
 import io.yupiik.asciidoc.parser.Parser;
 import io.yupiik.asciidoc.parser.resolver.ContentResolver;
 import io.yupiik.asciidoc.parser.resolver.RelativeContentResolver;
-import io.yupiik.asciidoc.renderer.html.AsciidoctorLikeHtmlRenderer;
 import io.yupiik.asciidoc.renderer.html.AsciidoctorLikeHtmlRenderer.Configuration;
 
 @Singleton
@@ -70,7 +69,7 @@ public class AsciidocConverter {
         Document document = parser.parse(content, new Parser.ParserContext(contentResolver));
         // Renderer is not thread-safe and must not be shared
         final Configuration configuration = createConfiguration(asciidocAttributes, templateAttributes);
-        AsciidoctorLikeHtmlRenderer renderer = new AsciidoctorLikeHtmlRenderer(configuration);
+        final AsciidocQuteRenderer renderer = new AsciidocQuteRenderer(configuration);
         renderer.visit(document);
         return renderer.result();
     }

--- a/asciidoc/runtime/src/main/java/io/quarkiverse/qute/web/asciidoc/runtime/AsciidocQuteRenderer.java
+++ b/asciidoc/runtime/src/main/java/io/quarkiverse/qute/web/asciidoc/runtime/AsciidocQuteRenderer.java
@@ -1,0 +1,69 @@
+package io.quarkiverse.qute.web.asciidoc.runtime;
+
+import io.yupiik.asciidoc.model.Body;
+import io.yupiik.asciidoc.model.Header;
+import io.yupiik.asciidoc.model.Listing;
+import io.yupiik.asciidoc.renderer.html.AsciidoctorLikeHtmlRenderer;
+
+import java.util.LinkedHashSet;
+import java.util.Map;
+
+public class AsciidocQuteRenderer extends AsciidoctorLikeHtmlRenderer {
+    private Map<String, String> specificAttributes;
+    private LinkedHashSet<String> beforeBodyEndInjections = null;
+
+    public AsciidocQuteRenderer(final Configuration configuration) {
+        super(configuration);
+    }
+
+    @Override
+    public void visitHeader(final Header header) {
+        specificAttributes = header.attributes();
+        super.visitHeader(header);
+    }
+
+    @Override
+    public void visitListing(final Listing element) {
+        if ("mermaid".equals(element.options().get(""))) {
+            visitMermaid(element);
+            return;
+        }
+        super.visitListing(element);
+    }
+
+    @Override
+    public void visitBody(Body body) {
+        try {
+            super.visitBody(body);
+        } finally {
+            // we could use beforeBodyEnd() too but can be bypassed if visit(Document) is replaced by visitBody(Body)
+            if (beforeBodyEndInjections != null) {
+                builder.append(String.join("\n", beforeBodyEndInjections)).append('\n');
+            }
+        }
+    }
+
+    // here the idea is to just run mermaid.js, we do not want to depends on a 3rd party as asciidoctor-diagram
+    protected void visitMermaid(final Listing element) {
+        // note: should we call escape(), can break mermaid but not escaping can break html
+        final var diagram = '\n' + element.value().strip() + '\n';
+        builder.append("<pre");
+        writeCommonAttributes(element.options(), c -> "mermaid" + (c != null ? ' ' + c : ""));
+        builder.append(">");
+        builder.append(diagram);
+        builder.append("</pre>\n");
+
+        // mermaid-skipModule attribute enables to let the injection be done with the layout template
+        // (preferred in general since it can be bundled)
+        // we do not disable the injection by default just to have it working by default
+        if (!configuration.getAttributes().containsKey("mermaid-skipModule") &&
+                (specificAttributes == null || !specificAttributes.containsKey("mermaid-skipModule"))) {
+            if (beforeBodyEndInjections == null) {
+                beforeBodyEndInjections = new LinkedHashSet<>();
+            }
+            beforeBodyEndInjections.add("<script type=\"module\">" +
+                    "import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';" +
+                    "</script>");
+        }
+    }
+}

--- a/asciidoc/runtime/src/test/java/io/quarkiverse/qute/web/asciidoc/runtime/AsciidocQuteRendererTest.java
+++ b/asciidoc/runtime/src/test/java/io/quarkiverse/qute/web/asciidoc/runtime/AsciidocQuteRendererTest.java
@@ -1,0 +1,45 @@
+package io.quarkiverse.qute.web.asciidoc.runtime;
+
+import io.yupiik.asciidoc.parser.Parser;
+import io.yupiik.asciidoc.renderer.html.AsciidoctorLikeHtmlRenderer;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AsciidocQuteRendererTest {
+    @Test
+    void mermaid() {
+        assertRendered(
+                """
+                        [mermaid]
+                        ....
+                        sequenceDiagram
+                            participant Alice
+                            participant Bob
+                            Alice->>Bob: Hello Bob, how are you?
+                            Bob-->>Alice: Great!
+                        ....
+                        """,
+                """
+                        <pre class="mermaid">
+                        sequenceDiagram
+                            participant Alice
+                            participant Bob
+                            Alice->>Bob: Hello Bob, how are you?
+                            Bob-->>Alice: Great!
+                        </pre>
+                        <script type="module">import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';</script>
+                        """
+        );
+    }
+
+    private void assertRendered(final String adoc, final String html) {
+        final var parser = new Parser();
+        final var ast = parser.parseBody(adoc, new Parser.ParserContext((ref, encoding) -> Optional.empty()));
+        final var renderer = new AsciidocQuteRenderer(new AsciidoctorLikeHtmlRenderer.Configuration());
+        renderer.visitBody(ast);
+        assertEquals(html, renderer.result());
+    }
+}


### PR DESCRIPTION
Main idea of the PR is to show how to integrate custom extensions (I used inheritance since it will be built-in but in an user land decoration and delegate pattern is preferred since it can compose features more easily).

I didn't enable end user to provider a renderer factory but I think it would be neat since it is how end users can handle all block kind support - for example at work we have a custom "icon" macro which uses some internal software to get task status, as of today this is not doable with qute-asciidoc.

